### PR TITLE
Update author-config.csv

### DIFF
--- a/configs/author-config.csv
+++ b/configs/author-config.csv
@@ -22,7 +22,7 @@ https://github.com/AY1920S2-CS2103T-F09-4/main.git,master,vuhieunguyen,e0323154@
 https://github.com/AY1920S2-CS2103T-F10-1/main.git,master,chrisjwelly,e0324077@u.nus.edu,CS2103T-F10-1 CHRI..ELLY,Christian James Welly;chrisjwelly,
 https://github.com/AY1920S2-CS2103T-F10-1/main.git,master,helloImHai,e0324816@u.nus.edu,CS2103T-F10-1 NGUY.. HAI,Hai Nguyen;helloImHai;helloimhai,
 https://github.com/AY1920S2-CS2103T-F10-1/main.git,master,wardetu,e0324078@u.nus.edu,CS2103T-F10-1 NGUY..OANG,Hoang;Hoang Nguyen;huutienvt98;wardetu,
-https://github.com/AY1920S2-CS2103T-F10-1/main.git,master,nhamhung,e0323236@u.nus.edu,CS2103T-F10-1 NHAM..HUNG,Nham Quoc Hung;nhamhung,
+https://github.com/AY1920S2-CS2103T-F10-1/main.git,master,nhamhung,e0323236@u.nus.edu,CS2103T-F10-1 NHAM..HUNG,Nham Quoc Hung;Nham Hung;nhamhung,
 https://github.com/AY1920S2-CS2103T-F10-1/main.git,master,duongphammmm,e0148683@u.nus.edu,CS2103T-F10-1 PHAM..UONG,PHAM THUY DUONG;duongphammmm,
 https://github.com/AY1920S2-CS2103T-F10-2/main.git,master,gerhean,e0323230@u.nus.edu,CS2103T-F10-2 CHAN..HEAN,Chan Ger Hean;Ger Hean;gerhean,
 https://github.com/AY1920S2-CS2103T-F10-2/main.git,master,FeliciaTay,e0323765@u.nus.edu,CS2103T-F10-2 FELI.. YEE,FeliciaTay,


### PR DESCRIPTION
Currently the tp-dashboard only display my code contribution with author name "nhamhung" which is also my github username. However, I realised that the rest of my commits are under author name "Nham Hung" instead! Hope this will allow RepoSense to count the commit from my other author name as well.